### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ libnetfilter-cthelper (1.0.0-2) UNRELEASED; urgency=medium
   * Transition to automatic debug package (from: libnetfilter-cthelper0-
     dbg).
   * Use secure URI in Vcs control header.
+  * Use versioned copyright format URI.
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Sat, 27 Oct 2018 15:41:11 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libnetfilter-cthelper (1.0.0-2) UNRELEASED; urgency=medium
+
+  * Transition to automatic debug package (from: libnetfilter-cthelper0-
+    dbg).
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Sat, 27 Oct 2018 15:41:11 +0000
+
 libnetfilter-cthelper (1.0.0-1) unstable; urgency=low
 
   * Initial packaging

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ libnetfilter-cthelper (1.0.0-2) UNRELEASED; urgency=medium
 
   * Transition to automatic debug package (from: libnetfilter-cthelper0-
     dbg).
+  * Use secure URI in Vcs control header.
 
  -- Jelmer Vernooĳ <jelmer@debian.org>  Sat, 27 Oct 2018 15:41:11 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libnetfilter-cthelper
 Section: libs
 Priority: extra
 Maintainer: Alexander Wirt <formorer@debian.org>
-Build-Depends: debhelper (>= 9), libmnl-dev (>= 1.0.1), pkg-config
+Build-Depends: debhelper (>= 9.20160114), libmnl-dev (>= 1.0.1), pkg-config
 Standards-Version: 3.9.4
 Vcs-Git: git://github.com/formorer/pkg-libnetfilter-cthelper.git
 Vcs-Browser: https://github.com/formorer/pkg-libnetfilter-cthelper
@@ -17,20 +17,6 @@ Description: userspace-helper for netfilter library
  interface to the user-space helper infrastructure available since Linux kernel
  3.6. With this library, you register, configure, enable and disable user-space
  helpers.
-
-Package: libnetfilter-cthelper0-dbg
-Section: debug
-Architecture: any
-Depends: libnetfilter-cthelper0 (= ${binary:Version}),
-         ${misc:Depends},
-         ${shlibs:Depends}
-Description: Debugging symbols for libnetfilter-cthelper0
- libnetfilter_cthelper is the userspace library that provides the programming
- interface to the user-space helper infrastructure available since Linux kernel
- 3.6. With this library, you register, configure, enable and disable user-space
- helpers.
- .
- This package provides the debugging symbols.
 
 Package: libnetfilter-cthelper0-dev
 Section: libdevel

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: Alexander Wirt <formorer@debian.org>
 Build-Depends: debhelper (>= 9.20160114), libmnl-dev (>= 1.0.1), pkg-config
 Standards-Version: 3.9.4
-Vcs-Git: git://github.com/formorer/pkg-libnetfilter-cthelper.git
+Vcs-Git: https://github.com/formorer/pkg-libnetfilter-cthelper.git
 Vcs-Browser: https://github.com/formorer/pkg-libnetfilter-cthelper
 
 Package: libnetfilter-cthelper0

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://dep.debian.net/deps/dep5
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: libnetfilter-cthelper
 Source: http://www.netfilter.org/projects/libnetfilter_cthelper/index.html
 

--- a/debian/rules
+++ b/debian/rules
@@ -13,4 +13,4 @@
 	dh $@
 
 override_dh_strip:
-	dh_strip --dbg-package=libnetfilter-cthelper0-dbg
+	dh_strip --dbgsym-migration='libnetfilter-cthelper0-dbg (<< 1.0.0-2~)'


### PR DESCRIPTION
Fix some issues reported by lintian
* Transition to automatic debug package (from: libnetfilter-cthelper0-dbg).
* Use versioned copyright format URI.
* Use secure URI in Vcs control header.
